### PR TITLE
Fixed crashing on ICS

### DIFF
--- a/app/src/main/java/com/flavienlaurent/tickplusdrawable/MainActivity.java
+++ b/app/src/main/java/com/flavienlaurent/tickplusdrawable/MainActivity.java
@@ -1,13 +1,16 @@
 package com.flavienlaurent.tickplusdrawable;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 
 
 public class MainActivity extends Activity {
 
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -16,7 +19,13 @@ public class MainActivity extends Activity {
         View view = findViewById(R.id.view);
 
         final TickPlusDrawable tickPlusDrawable = new TickPlusDrawable(getResources().getDimensionPixelSize(R.dimen.stroke_width), getResources().getColor(android.R.color.holo_blue_dark), Color.WHITE);
-        view.setBackground(tickPlusDrawable);
+
+        if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN) {
+            view.setBackgroundDrawable(tickPlusDrawable);
+        } else {
+            view.setBackground(tickPlusDrawable);
+        }
+
         view.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {


### PR DESCRIPTION
Just a minor thing. 
You set minSdkVersion to 14 but the setBackground method is available since 16.
