### PR TITLE
fixed opacity

### DIFF
--- a/app/src/main/java/com/flavienlaurent/tickplusdrawable/TickPlusDrawable.java
+++ b/app/src/main/java/com/flavienlaurent/tickplusdrawable/TickPlusDrawable.java
@@ -183,7 +183,7 @@ public class TickPlusDrawable extends Drawable {
 
     @Override
     public int getOpacity() {
-        return PixelFormat.OPAQUE;
+        return PixelFormat.TRANSLUCENT;
     }
 
     private Property<TickPlusDrawable, Integer> mBackgroundColorProperty = new Property<TickPlusDrawable, Integer>(Integer.class, "bg_color") {


### PR DESCRIPTION
I found this bug when fixing https://github.com/flavienlaurent/tickplusdrawable/pull/2.
It seems like the older Androids render a Drawable differently:

![screenshot2](https://cloud.githubusercontent.com/assets/616399/3928987/8f9142fa-2415-11e4-8995-8db267e47a67.png)
![screenshot1](https://cloud.githubusercontent.com/assets/616399/3928986/8f8f4612-2415-11e4-98d5-43f9261d068a.png)

I am no expert on this but the [API doc](http://developer.android.com/reference/android/graphics/drawable/Drawable.html#getOpacity%28%29) suggests a Drawable to be as conservative as possible so I changed the opacity to TRANSLUCENT and that fixed the issue.
